### PR TITLE
feat(room): Add story property to Room

### DIFF
--- a/lib/from_honeybee/geometry/room.rb
+++ b/lib/from_honeybee/geometry/room.rb
@@ -96,6 +96,26 @@ module FromHoneybee
       if @hash[:multiplier] and @hash[:multiplier] != 1
         os_thermal_zone.setMultiplier(@hash[:multiplier])
       end
+
+      # assign the story
+      if @hash[:story]  # the users has specified the name of the story
+        story = openstudio_model.getBuildingStoryByName(@hash[:story])
+        if story.empty?  # first time that this story has been referenced
+          story = OpenStudio::Model::BuildingStory.new(openstudio_model)
+          story.setName(@hash[:story])
+        else
+          story = story.get
+        end
+      else  # give the room a dummy story so that it works with David's measures
+        story = openstudio_model.getBuildingStoryByName('UndefiniedStory')
+        if story.empty?  # first time that this story has been referenced
+          story = OpenStudio::Model::BuildingStory.new(openstudio_model)
+          story.setName('UndefiniedStory')
+        else
+          story = story.get
+        end
+      end
+      os_space.setBuildingStory(story)
       
       # assign all of the faces to the room
       @hash[:faces].each do |face|

--- a/spec/tests/honeybee_model_spec.rb
+++ b/spec/tests/honeybee_model_spec.rb
@@ -74,6 +74,11 @@ RSpec.describe FromHoneybee do
     openstudio_space = openstudio_space.get
     expect(openstudio_space.nameString).to eq 'Tiny_House_Office'
 
+    openstudio_story = openstudio_space.buildingStory 
+    expect(openstudio_story.empty?).to be false
+    openstudio_story = openstudio_story.get
+    expect(openstudio_story.nameString).to eq 'UndefiniedStory'
+
     openstudio_vertices = openstudio_surface.vertices
     expect(openstudio_vertices.empty?).to be false
     expect(openstudio_vertices.size).to be >= 3


### PR DESCRIPTION
This commit enables the energy-model-measure to use the story properties recently added to the Room schema.  It also adds rooms to a dummy story if no stories are specified.

This way, David's measures should always work with the Model output from this measure.