### PR TITLE
feat(urbanopt): Add gemfile for URBANopt

### DIFF
--- a/lib/files/urbanopt_Gemfile
+++ b/lib/files/urbanopt_Gemfile
@@ -1,0 +1,29 @@
+source 'http://rubygems.org'
+
+ruby '2.2.4'
+
+allow_local = ENV['FAVOR_LOCAL_GEMS']
+
+gem 'urbanopt-reopt', '0.2.1'
+
+if allow_local && File.exist?('../urbanopt-scenario-gem')
+  gem 'urbanopt-scenario', path: '../urbanopt-scenario-gem'
+elsif allow_local
+  gem 'urbanopt-scenario', github: 'URBANopt/urbanopt-scenario-gem', branch: 'develop'
+else
+  gem 'urbanopt-scenario', '0.2.0'
+end
+
+if allow_local && File.exist?('../urbanopt-geojson-gem')
+  gem 'urbanopt-geojson', path: '../urbanopt-geojson-gem'
+elsif allow_local
+  gem 'urbanopt-geojson', github: 'URBANopt/urbanopt-geojson-gem', branch: 'develop'
+else
+  gem 'urbanopt-geojson', '0.2.0'
+end
+
+# simplecov has an unnecessary dependency on native json gem, use fork that does not require this
+gem 'simplecov', github: 'NREL/simplecov'
+
+# Specify exact rack version temporarily to work with Ruby 2.2.4
+gem 'rack', '2.1.2'


### PR DESCRIPTION
It seems like this is the last thing that is needed to bypass the `uo -p` command and generate all of the files needed for an urbanopt simulation ourselves.

However, including this gemfile means that we will have to update it whenever we want to upgrade to a new version of URBANopt.

I also simplified some of the code in the mapper and improved the docstrings.