### PR TITLE
feat(name): Change gem name to honeybee-openstudio

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-[![Build Status](https://travis-ci.org/ladybug-tools/energy-model-measure.svg?branch=master)](https://travis-ci.org/ladybug-tools/energy-model-measure)
+[![Build Status](https://travis-ci.org/ladybug-tools/honeybee-openstudio-gem.svg?branch=master)](https://travis-ci.org/ladybug-tools/honeybee-openstudio-gem)
 
-# energy-model-measure
+# honeybee-openstudio-gem
 
-Library and measures for converting Honeybee JSONs to/from OpenStudio.
+Library and measures for translating between Honeybee JSON schema and OpenStudio Model schema (OSM).
 
 
 ## Run the measures of this repo using OpenStudio CLI
@@ -43,11 +43,11 @@ where the items in parentheses should be replaced with specific file paths:
 ## Local Development
 1. Clone this repo locally
 ```
-git clone git@github.com:ladybug-tools/energy-model-measure
+git clone git@github.com:ladybug-tools/honeybee-openstudio-gem
 
 # or
 
-git clone https://github.com/ladybug-tools/energy-model-measure
+git clone https://github.com/ladybug-tools/honeybee-openstudio-gem
 ```
 
 2. Install dependencies:
@@ -60,35 +60,35 @@ gem install openstudio-extension
 ```
 Then, the specific dependencies of this measure can be installed by running:
 ```
-cd energy-model-measure
+cd honeybee-openstudio-gem
 bundle update
 ```
 
 3. Run Core Library Tests:
 ```
-cd energy-model-measure
+cd honeybee-openstudio-gem
 bundle exec rake
 ```
 
 4. Run Measure Tests:
 ```
-cd energy-model-measure/lib/measures/from_honeybee_model/tests/
+cd honeybee-openstudio-gem/lib/measures/from_honeybee_model/tests/
 bundle exec ruby from_honeybee_model_test.rb
 
-cd energy-model-measure/lib/measures/from_honeybee_simulation_parameter/tests/
+cd honeybee-openstudio-gem/lib/measures/from_honeybee_simulation_parameter/tests/
 bundle exec ruby from_honeybee_simulation_parameter_test.rb
 ```
 
-coverage report will be output to `energy-model-measure/coverage/index.html`
+coverage report will be output to `honeybee-openstudio-gem/coverage/index.html`
 
 5. Update doc_templates:
 ```
-cd energy-model-measure
+cd honeybee-openstudio-gem
 bundle exec rake openstudio:update_copyright
 ```
 
 6. See all available rake tasks:
 ```
-cd energy-model-measure
+cd honeybee-openstudio-gem
 bundle exec rake -T
 ```

--- a/honeybee-openstudio.gemspec
+++ b/honeybee-openstudio.gemspec
@@ -4,14 +4,14 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'from_honeybee/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = 'honeybee-energy-model-measure'
+  spec.name          = 'honeybee-openstudio'
   spec.version       = FromHoneybee::VERSION
   spec.authors       = ['Tanushree Charan', 'Dan Macumber', 'Chris Mackey', 'Mostapha Sadeghipour Roudsari']
   spec.email         = ['tanushree.charan@nrel.gov', 'chris@ladybug.tools']
 
-  spec.summary       = 'Library and measures for converting Honeybee JSONs to/from OpenStudio'
-  spec.description   = 'Library and measures for converting Heoneybee JSONs to/from OpenStudio'
-  spec.homepage      = 'https://github.com/ladybug-tools-in2/energy-model-measure'
+  spec.summary       = 'Gem for translating between Honeybee JSON and OpenStudio Model.'
+  spec.description   = 'Library and measures for translating between Honeybee JSON schema and OpenStudio Model schema (OSM).'
+  spec.homepage      = 'https://github.com/ladybug-tools/honeybee-openstudio-gem'
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.

--- a/lib/files/urbanopt_Gemfile
+++ b/lib/files/urbanopt_Gemfile
@@ -22,8 +22,8 @@ else
   gem 'urbanopt-geojson', '0.2.0'
 end
 
-# include the ladybug tools energy-model-measure
-gem 'honeybee-energy-model-measure', github: 'ladybug-tools/energy-model-measure'
+# include the honeybee-openstudio-gem
+gem 'honeybee-openstudio', github: 'ladybug-tools/honeybee-openstudio-gem'
 
 # simplecov has an unnecessary dependency on native json gem, use fork that does not require this
 gem 'simplecov', github: 'NREL/simplecov'


### PR DESCRIPTION
It seems like energy-model-measure has become a misnomer at this point since the package is currently a lot more than a measure.  It's at least 2 measures (from_honeybee_model and from_honeybee_simulation_parameter) as well as a whole library of translators that are used by the measures but can also be run independently of these measures. 

So this commit changes the name of the this repo to honeybee-openstudio-gem and makes the official name of the Ruby gem honeybee-openstudio.